### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/optiplex/services/proxy/Dockerfile
+++ b/optiplex/services/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`